### PR TITLE
Clarify recent root references in EIP-8141

### DIFF
--- a/EIPS/eip-recent_root_references.md
+++ b/EIPS/eip-recent_root_references.md
@@ -13,47 +13,36 @@ requires: 7843, 8141
 
 ## Abstract
 
-Adds recent root references to EIP-8141 frame transactions.
-
-A root source is a source address plus a salt. It stores roots over time, with each root keyed by the slot in which it was written. A frame transaction may declare recent root references of the form:
-
-```text
-(source_id, slot, root)
-```
-
-Before a frame transaction runs, clients check each reference against the state immediately before that transaction. The check succeeds only if the named root is stored for the named source and slot, and the slot is still recent. Validation code can then read the verified reference through transaction introspection.
+EIP-8141 frame transactions can reference recent application-published roots without reading mutable storage during validation. Applications publish roots to a system contract keyed by `(source_id, slot)`, where `source_id` derives from the writer address and a salt. Each reference is verified by the protocol before any dependent frame executes.
 
 ## Motivation
 
-EIP-8141 validation must not read arbitrary storage controlled by another account or application in the public mempool. Some validation rules still need to depend on recent roots, such as privacy tree roots, wallet authorization roots, or account validation roots.
+EIP-8141 validation must not read arbitrary storage controlled by another account or application in the public mempool. Some validation rules still need to depend on recent application state: privacy tree roots, wallet authorization roots, account validation roots.
 
-Recent root references let a transaction explicitly name one recent root in its signed transaction envelope. Each reference maps to one system-contract storage key and can be checked before validation code runs.
+An application publishes a root for the current slot to a system contract. Transactions name a `(source_id, slot, root)` tuple that the protocol verifies before any frame that depends on it. Validation logic can then rely on the named root without reading mutable storage.
 
-Privacy applications often keep a tree of commitments and prove spends against a recent tree root. With this EIP, the application writes a root for a recent slot, and spend transactions reference that root directly instead of reading the application's changing tree state during validation.
+Privacy applications, for example, keep a tree of commitments and prove spends against a recent tree root. With this EIP, the application writes a root each slot, and spend transactions reference that root directly instead of reading the application's changing tree state during validation.
 
 ## Specification
 
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
 
-This specification is a delta against EIP-8141. Terms not defined here, including `FrameTx`, `FRAME_TX_TYPE`, `VERIFY`, `EXPIRY_VERIFIER`, frame modes, and `TXPARAM`, have the meanings defined in EIP-8141.
+This specification is a delta against EIP-8141. Terms not defined here, including `FrameTx`, `FRAME_TX_TYPE`, `VERIFY`, `EXPIRY_VERIFIER`, frame modes, `compute_sig_hash`, `FRAMEDATALOAD`, `FRAMEDATACOPY`, and `FRAMEPARAM`, have the meanings defined in EIP-8141.
 
 ### Constants
 
-| Name                                 |                                                                            Value |
-| ------------------------------------ | -------------------------------------------------------------------------------: |
-| `FORK_TIMESTAMP`                     |                                                                            `TBD` |
-| `RECENT_ROOT_ADDRESS`                 |                                                                            `TBD` |
-| `RECENT_ROOT_CODE`                    |                                                                            `TBD` |
-| `RECENT_ROOT_LENGTH`                  |                                                                           `8192` |
-| `RECENT_ROOT_USABLE_WINDOW`           |                                                                           `8191` |
-| `MAX_RECENT_ROOT_REFERENCES`          |                                                                             `16` |
-| `RECENT_ROOT_ENTRY_DOMAIN`            |                                                  `keccak256("RECENT_ROOT_ENTRY")` |
-| `RECENT_ROOT_STORAGE_DOMAIN`          |                                                `keccak256("RECENT_ROOT_STORAGE")` |
-| `RECENT_ROOT_REFERENCE_ADDRESS_GAS`   |                                                       `ACCESS_LIST_ADDRESS_COST` |
-| `RECENT_ROOT_REFERENCE_GAS`           | `ACCESS_LIST_STORAGE_KEY_COST + 2 * KECCAK256_BASE_GAS + 7 * KECCAK256_WORD_GAS` |
-| `TXPARAM_RECENT_ROOT_REFERENCE_COUNT` |                                                                           `0x0D` |
-| `RECENTROOTREFLOAD`                   |                                                                           `0xB4` |
-| `RECENTROOTREFLOAD_GAS`               |                                                                              `3` |
+| Name                                |                              Value |
+| ----------------------------------- | ---------------------------------: |
+| `FORK_TIMESTAMP`                    |                              `TBD` |
+| `RECENT_ROOT_ADDRESS`               |                              `TBD` |
+| `RECENT_ROOT_CODE`                  |                              `TBD` |
+| `RECENT_ROOT_REFERENCE_VERIFIER`    |                              `TBD` |
+| `RECENT_ROOT_REFERENCE_CODE`        |                              `TBD` |
+| `RECENT_ROOT_REFERENCE_DATA_LENGTH` |                               `72` |
+| `RECENT_ROOT_LENGTH`                |                             `8192` |
+| `RECENT_ROOT_USABLE_WINDOW`         |                             `8191` |
+| `RECENT_ROOT_ENTRY_DOMAIN`          |    `keccak256("RECENT_ROOT_ENTRY")` |
+| `RECENT_ROOT_STORAGE_DOMAIN`        |  `keccak256("RECENT_ROOT_STORAGE")` |
 
 All concatenations below use fixed-length encodings. Domains are 32 bytes. Addresses are 20 bytes. Slots and indices are unsigned 64-bit big-endian integers. Roots, salts, source identifiers, entry hashes, and storage keys are 32 bytes.
 
@@ -162,218 +151,117 @@ The call follows normal EVM execution and gas accounting. A successful call retu
 
 Each `(source_id, S)` has at most one referenceable root on the canonical chain. Multiple writes by the same source address and salt during slot `S` target the same storage key. If multiple writes are included, the final write in canonical block execution order overwrites earlier writes. Only that final root is referenceable beginning in slot `S + 1`.
 
-### Transaction payload
+### Recent root reference frame
 
-The pre-fork EIP-8141 frame-transaction payload has eight fields:
+A **recent root reference frame** is a frame whose `target` equals `RECENT_ROOT_REFERENCE_VERIFIER`. It declares one reference `(source_id, slot, root)` carried in `frame.data`.
 
-```text
-[chain_id, nonce, sender, frames,
- max_priority_fee_per_gas, max_fee_per_gas,
- max_fee_per_blob_gas, blob_versioned_hashes]
-```
+A recent root reference frame is invalid unless:
 
-The post-fork frame-transaction payload becomes:
+- `frame.mode == VERIFY`,
+- `frame.flags == 0`,
+- `frame.value == 0`, and
+- `len(frame.data) == RECENT_ROOT_REFERENCE_DATA_LENGTH`.
 
-```text
-[chain_id, nonce, sender, frames,
- max_priority_fee_per_gas, max_fee_per_gas,
- max_fee_per_blob_gas, blob_versioned_hashes,
- recent_root_references]
-```
-
-where:
+`frame.data` is laid out as:
 
 ```text
-recent_root_references = [[source_id, slot, root], ...]
+source_id : bytes[0:32]
+slot      : bytes[32:40]   # uint64 big-endian
+root      : bytes[40:72]
 ```
 
-`recent_root_references` MUST be an RLP list. Each item MUST be an RLP list of exactly three elements. `source_id` MUST be a byte string of length 32. `slot` MUST be a canonical RLP integer satisfying `slot < 2**64`. `root` MUST be a byte string of length 32. Consensus treats `root` as opaque bytes; applications define what it commits to. The number of references MUST NOT exceed `MAX_RECENT_ROOT_REFERENCES`.
+EIP-8141's transaction payload, frame layout, frame execution rules, and gas accounting are otherwise unchanged. The verifier's work is paid from `frame.gas_limit`.
 
-The `slot` field is a slot number, not a timestamp or block number.
-
-The frame layout and frame execution rules are otherwise unchanged. `recent_root_references` is a top-level transaction field and is included in `compute_sig_hash(tx)`.
-
-The post-fork signature hash follows EIP-8141 over the nine-field payload:
-
-```python
-def compute_sig_hash(tx: FrameTx) -> Hash:
-    for i, frame in enumerate(tx.frames):
-        if frame.mode == VERIFY and frame.target != EXPIRY_VERIFIER:
-            tx.frames[i].data = Bytes()
-    return keccak(bytes([FRAME_TX_TYPE]) + rlp(tx))
-```
-
-where `rlp(tx)` is the post-fork nine-field payload. `recent_root_references` is not elided by the VERIFY-frame data elision rule.
-
-Frame data, including VERIFY frame data, MUST NOT add, remove, or modify the transaction's recent root reference set.
-
-### Static validity
-
-Decoders MUST reject a post-fork frame transaction if any of the following is true:
-
-* the payload does not match the post-fork schema;
-* `recent_root_references` is not an RLP list;
-* `len(recent_root_references) > MAX_RECENT_ROOT_REFERENCES`;
-* any reference is not an RLP list of exactly three elements;
-* any `source_id` is not a byte string of length 32;
-* any `slot` is not a canonical RLP integer or satisfies `slot >= 2**64`;
-* any `root` is not a byte string of length 32.
-
-### Reference validity
-
-Within block execution, recent root references are checked after the EIP-8141 nonce check and before frame execution, against the transaction pre-state. The transaction pre-state includes all prior transactions in the same block.
-
-Competing blocks at the same slot may have different recent-root state, and a reference is valid only in a block whose transaction pre-state contains the referenced entry. `current_slot` is the consensus slot of that block.
-
-A recent root reference `(source_id, slot, root)` is valid only if:
+EIP-8141's VERIFY-mode data-elision rule is extended to a set of **public-data verifiers**:
 
 ```text
-1 <= current_slot - slot <= RECENT_ROOT_USABLE_WINDOW
-i = slot mod RECENT_ROOT_LENGTH
-entry_hash = keccak256(
-    RECENT_ROOT_ENTRY_DOMAIN ||
-    source_id ||
-    uint64_be(slot) ||
-    root
-)
-storage_key = keccak256(
-    RECENT_ROOT_STORAGE_DOMAIN ||
-    source_id ||
-    uint64_be(i)
-)
-RECENT_ROOT_ADDRESS[storage_key] == entry_hash
+PUBLIC_DATA_VERIFIERS = {EXPIRY_VERIFIER, RECENT_ROOT_REFERENCE_VERIFIER}
 ```
 
-If any reference is invalid, the transaction is invalid and no frame is executed. A block containing such a transaction is invalid.
+For VERIFY frames whose `target` is in `PUBLIC_DATA_VERIFIERS`, `frame.data` is not elided by `compute_sig_hash(tx)`, and `FRAMEDATALOAD`, `FRAMEDATACOPY`, and `FRAMEPARAM(0x04)` return the frame's actual data and length. This binds the reference to the signature and makes it readable from other frames.
 
-Duplicate references are valid. They are checked, charged, and preserved independently. Accessed address and storage-key sets deduplicate normally.
+### Recent root reference verifier
 
-Each valid reference MUST add `RECENT_ROOT_ADDRESS` and its `storage_key` to the transaction's accessed address and storage-key sets. This affects warm/cold gas accounting only.
-
-### Access lists
-
-Recent root writes are ordinary writes to `RECENT_ROOT_ADDRESS[storage_key]`.
-
-### Gas accounting
-
-For post-fork frame transactions, the EIP-8141 gas-limit formula is modified to include recent root references:
+When a recent root reference frame executes, the verifier performs the following check against the state at frame entry:
 
 ```text
-tx_gas_limit =
-    FRAME_TX_INTRINSIC_COST
-    + len(tx.frames) * FRAME_TX_PER_FRAME_COST
-    + calldata_cost(recent_root_calldata)
-    + recent_root_reference_intrinsic_gas
-    + sum(frame.gas_limit for all frames)
+source_id   = frame.data[0:32]
+slot        = uint64_be(frame.data[32:40])
+root        = frame.data[40:72]
+
+assert 1 <= current_slot - slot <= RECENT_ROOT_USABLE_WINDOW
+
+i           = slot mod RECENT_ROOT_LENGTH
+storage_key = keccak256(RECENT_ROOT_STORAGE_DOMAIN || source_id || uint64_be(i))
+entry_hash  = keccak256(RECENT_ROOT_ENTRY_DOMAIN   || source_id || uint64_be(slot) || root)
+
+assert state.storage[RECENT_ROOT_ADDRESS][storage_key] == entry_hash
 ```
 
-where:
+If any assertion fails, the frame reverts. Per EIP-8141, a revert in a VERIFY frame renders the transaction invalid.
 
-```text
-recent_root_reference_intrinsic_gas =
-    0
-        if len(recent_root_references) == 0
-    RECENT_ROOT_REFERENCE_ADDRESS_GAS
-        + len(recent_root_references) * RECENT_ROOT_REFERENCE_GAS
-        otherwise
-```
+A successful check returns zero bytes and adds `RECENT_ROOT_ADDRESS` and the computed `storage_key` to the transaction's accessed address and storage-key sets. This affects warm/cold gas accounting only.
 
-and:
+Duplicate recent root reference frames are valid. Each is checked and charged independently.
 
-```text
-recent_root_calldata = rlp(tx.frames) || rlp(recent_root_references)
-```
-
-The EIP-7623 calldata cost MUST be computed over `recent_root_calldata` as one byte string.
-
-`RECENT_ROOT_REFERENCE_GAS` covers one declared storage key and the two Keccak computations used to derive `storage_key` and `entry_hash`.
-
-### TXPARAM and RECENTROOTREFLOAD
-
-One new `TXPARAM` index and one new opcode are added:
-
-| Name                                 |  Value | Return value                 |
-| ------------------------------------ | -----: | ---------------------------- |
-| `TXPARAM_RECENT_ROOT_REFERENCE_COUNT` | `0x0D` | `len(recent_root_references)` |
-
-`TXPARAM(TXPARAM_RECENT_ROOT_REFERENCE_COUNT)` costs the standard `TXPARAM` gas.
-
-`RECENTROOTREFLOAD` pops two stack items:
-
-```text
-field
-index
-```
-
-where `field` is the top stack item and `index` is the second stack item. It pushes one word from `recent_root_references[index]`:
-
-| `field` | Return value                               |
-| ------: | ------------------------------------------ |
-|     `0` | `source_id`                                 |
-|     `1` | `slot`, as a zero-extended 256-bit integer |
-|     `2` | `root`                                     |
-
-`RECENTROOTREFLOAD` costs `RECENTROOTREFLOAD_GAS`. It MUST exceptional-halt if `index >= len(recent_root_references)` or `field > 2`.
-
-`RECENTROOTREFLOAD` reads only fields from the signed transaction envelope. It does not read recent root contract storage. It MAY be used in any frame mode, including VERIFY frames.
+Like the expiry verifier in EIP-8141, clients MAY skip explicit EVM execution at `RECENT_ROOT_REFERENCE_VERIFIER` and perform the check natively, provided the result is indistinguishable from executing `RECENT_ROOT_REFERENCE_CODE`.
 
 ### Public mempool handling
 
-Recent root storage is not exposed to validation code through EVM execution. During public mempool validation, recent root state may affect a transaction only through pre-execution reference checks and declared roots exposed by introspection.
+A recent root reference frame MAY appear at any position in the frame list. For matching the recognized validation-prefix shapes in EIP-8141, recent root reference frames are skipped, in the same manner as expiry verifier frames.
 
-Nodes SHOULD admit a transaction to the public mempool only if all declared recent root references are valid against the node's current head.
+Recent root reference frames are exempt from the generic validation-trace and banned-opcode rules. Their effect on mutable state outside `tx.sender` is bounded to one storage read on `RECENT_ROOT_ADDRESS` at a key fully determined by `frame.data`. Their `gas_limit` counts toward `MAX_VERIFY_GAS` when they appear in the validation prefix.
 
-Nodes SHOULD NOT admit a transaction while any reference has `slot >= current_slot`. Nodes MAY evict a transaction with any reference where `current_slot - slot >= RECENT_ROOT_LENGTH`.
+Nodes SHOULD admit a transaction to the public mempool only if every recent root reference frame is valid against the node's current head.
 
-Nodes SHOULD recheck pending transactions with recent root references when the head changes, when the node's current slot advances, or after any reorg that may affect referenced entries.
+Nodes SHOULD NOT admit a transaction while any recent root reference frame has `slot >= current_slot`. Nodes MAY evict a transaction with any recent root reference frame where `current_slot - slot >= RECENT_ROOT_LENGTH`.
+
+Nodes SHOULD recheck pending transactions with recent root reference frames when the head changes, when the node's current slot advances, or after any reorg that may affect referenced entries.
 
 ### Activation
 
-This EIP MUST activate at or after EIP-8141.
+This EIP MUST activate at or after EIP-8141. If `timestamp < FORK_TIMESTAMP`, clients MUST NOT apply this EIP.
 
-If `timestamp < FORK_TIMESTAMP`, clients MUST apply the pre-fork EIP-8141 `FRAME_TX_TYPE` schema and MUST NOT apply recent root logic.
+For every block `B` with `B.timestamp >= FORK_TIMESTAMP` whose parent has `parent.timestamp < FORK_TIMESTAMP`, clients MUST initialize both system contracts against `B`'s parent state before executing any transaction in `B`. For each `(address, code)` pair in `{(RECENT_ROOT_ADDRESS, RECENT_ROOT_CODE), (RECENT_ROOT_REFERENCE_VERIFIER, RECENT_ROOT_REFERENCE_CODE)}`:
 
-If `timestamp >= FORK_TIMESTAMP`, clients MUST apply the post-fork `FRAME_TX_TYPE` schema defined in this EIP.
+- If the account does not exist, clients MUST create it with balance 0, nonce 1, the given `code`, and empty storage.
+- If the account already exists with empty code and empty storage, clients MUST set its code to the given `code`, set its nonce to `max(existing_nonce, 1)`, preserve its balance, and leave storage empty.
 
-For every block `B` with `B.timestamp >= FORK_TIMESTAMP` whose parent has `parent.timestamp < FORK_TIMESTAMP`, clients MUST initialize `RECENT_ROOT_ADDRESS` against `B`'s parent state before executing any transaction in `B`.
-
-If `RECENT_ROOT_ADDRESS` does not exist, clients MUST create it with balance 0, nonce 1, code `RECENT_ROOT_CODE`, and empty storage.
-
-If `RECENT_ROOT_ADDRESS` already exists with empty code and empty storage, clients MUST set its code to `RECENT_ROOT_CODE`, set its nonce to `max(existing_nonce, 1)`, preserve its balance, and leave storage empty.
-
-The fork configuration MUST choose a `RECENT_ROOT_ADDRESS` with empty code and empty storage in the parent state of the first post-fork payload. If this condition is false at activation, the payload is invalid.
+The fork configuration MUST choose both addresses with empty code and empty storage in the parent state of the first post-fork payload. If this condition is false at activation, the payload is invalid.
 
 For all other blocks, clients MUST NOT run this initialization. Clients MUST handle reorgs across the fork boundary by applying or undoing this transition according to the canonical chain.
 
-Pre-fork frame transactions and authorizations bound to the pre-fork canonical signature hash do not survive the boundary and MUST be evicted from mempools and regenerated.
-
 ## Rationale
 
-EIP-8141 validation needs inputs that are known before validation starts. General reads from storage controlled by another account or application are unsafe for the public mempool because one mutable cell can invalidate many pending transactions.
+EIP-8141 validation needs inputs that are known before validation starts. General reads from storage controlled by another account or application are unsafe for the public mempool because one mutable cell can invalidate many pending transactions. Recent root references provide a narrow channel: each reference names one recent `bytes32` root and one system-contract storage key.
 
-Recent root references provide a narrow exception. The root is declared in the signed transaction envelope, checked by clients before validation code runs, and exposed to validation code only through introspection. Recent root references are intentionally narrow: each reference names one recent `bytes32` root and one system-contract storage key.
+### Frame-based delivery
+
+References are carried by VERIFY frames so that signature-hash binding, gas accounting, mempool prefix shapes, and introspection follow EIP-8141 unchanged. The pattern mirrors the expiry verifier; the one-off expiry exception generalizes into a `PUBLIC_DATA_VERIFIERS` set covering both. One reference per frame keeps `FRAMEDATALOAD` offsets fixed and gives each reference its own receipt entry. `MAX_FRAMES` already bounds the count.
+
+### Entry binding
 
 Each stored entry commits to the root source, slot, and root. This prevents an old root at the same array index, or a root from another root source, from satisfying a reference.
 
-References are limited to slots strictly before `current_slot`. During slot `S`, writes update index `S mod RECENT_ROOT_LENGTH`, but references to `S` are invalid and references old enough to share that index are expired. Current-slot writes therefore cannot invalidate currently valid references.
+### Window choice
+
+References are limited to slots strictly before `current_slot`. During slot `S`, writes update index `S mod RECENT_ROOT_LENGTH`, but references to `S` are invalid and references old enough to share that index are expired. Current-slot writes therefore cannot invalidate currently valid references. `RECENT_ROOT_LENGTH = 8192` gives `RECENT_ROOT_USABLE_WINDOW = 8191`, because the current slot is not referenceable.
+
+### Implicit source creation
 
 No creation transaction is required. A root source is created implicitly when a source address first writes with a new `(source_address, salt)` pair. Each root source has a bounded rolling window. Aggregate storage grows linearly with the number of written root sources. State growth is paid incrementally by the writes that create storage entries.
-
-For validation checks, each declared reference names exactly one storage key under `RECENT_ROOT_ADDRESS`.
-
-`RECENT_ROOT_LENGTH = 8192` gives `RECENT_ROOT_USABLE_WINDOW = 8191`, because the current slot is not referenceable.
-
-`MAX_RECENT_ROOT_REFERENCES = 16` bounds pre-execution reference checks while covering the expected root set for privacy, wallet authorization, and historical state root use cases.
 
 ## Backwards Compatibility
 
 This EIP does not modify EIP-7702 or other transaction types. An EIP-7702-delegated EOA may be a source address; `source_id` is derived from `msg.sender` of the write call.
 
+The transaction payload schema of EIP-8141 is unchanged. Pre-fork frame transactions remain valid under EIP-8141's pre-fork rules.
+
 References to slots before this EIP's activation are not satisfiable because recent root storage is empty at activation.
 
 ## Security Considerations
 
-Consensus treats `root` as an opaque `bytes32`. Applications define what it commits to and MUST bind the expected `source_id`, slot window, and root in their validation logic. For example, a privacy proof using root `R` should include `(source_id, slot, R)` or an application-specific commitment to those fields as a public input, and validation logic MUST check the same tuple through `RECENTROOTREFLOAD`.
+Consensus treats `root` as an opaque `bytes32`. Applications define what it commits to and MUST bind the expected `source_id`, slot window, and root in their validation logic. A privacy proof using root `R` should include `(source_id, slot, R)` or an application-specific commitment to those fields as a public input, and validation logic MUST read the same tuple from the recent root reference frame via `FRAMEDATALOAD` and check that it matches.
 
 Each `(source_id, slot)` has one referenceable root on the canonical chain. The referenceable root is last-write-wins according to canonical execution order and is finalized with the containing block. An application that needs multiple roots from the same slot SHOULD write an aggregate commitment.
 
@@ -381,7 +269,7 @@ This EIP does not guarantee inclusion of root writes. Applications that rely on 
 
 The same `(source_address, salt)` pair produces the same `source_id` on different chains, but each chain maintains independent recent root state. Proofs, bridge messages, and offchain attestations that carry recent root references MUST bind the intended chain domain outside the tuple.
 
-Recent roots create ordinary persistent storage under `RECENT_ROOT_ADDRESS`. Existing root sources overwrite at most `RECENT_ROOT_LENGTH` cells, while new root sources create additional cells. The natural pricing point for aggregate state growth is source creation, not recurring writes. Future versions MAY add a one-time source registration cost or first-write surcharge for each new `source_id`.
+Recent roots create ordinary persistent storage under `RECENT_ROOT_ADDRESS`. Existing root sources overwrite at most `RECENT_ROOT_LENGTH` cells, while new root sources create additional cells. The pricing point for aggregate state growth is source creation, not recurring writes. Future versions MAY add a one-time source registration cost or first-write surcharge for each new `source_id`.
 
 ## Copyright
 

--- a/EIPS/eip-recent_root_references.md
+++ b/EIPS/eip-recent_root_references.md
@@ -2,7 +2,7 @@
 eip: TBD
 title: Recent Root References for Frame Transactions
 description: Frame transactions can declare verified recent roots
-author: Thomas Thiery (@soispoke), Vitalik Buterin (@vbuterin)
+author: Thomas Thiery (@soispoke), Vitalik Buterin (@vbuterin), Toni Wahrstätter (@nerolation)
 discussions-to: TBD
 status: Draft
 type: Standards Track


### PR DESCRIPTION
This update modifies the abstract and motivation sections to clarify the functionality of recent root references in EIP-8141 frame transactions. It also adjusts the specification details, including transaction payload structure and gas accounting, to reflect the new recent root reference frame.